### PR TITLE
Remove Byte Order Mark (BOM) from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "com.alchemybow.railway",
   "version": "0.1.0",
   "displayName": "AlchemyBow.Railway",


### PR DESCRIPTION
JSON file contains a Byte Order Mark (BOM) at the beginning, which may cause some issues for services like OpenUPM to parse the file.